### PR TITLE
fix: expose include_statistics parameter in metadata resource

### DIFF
--- a/src/resources/metadata/band.py
+++ b/src/resources/metadata/band.py
@@ -10,7 +10,7 @@ from src.app import mcp
 from src.shared.raster.bands import band_metadata
 
 
-@mcp.resource("metadata://{file}/bands/{_dummy}")
+@mcp.resource("metadata://{file}/bands/{_dummy}{?include_statistics}")
 def get_raster_band_metadata(
     file: str,
     _dummy: str = "info",


### PR DESCRIPTION
## Summary
- add the include_statistics query placeholder to the band metadata resource URI template so FastMCP forwards the flag

## Testing
- pytest test/test_band_metadata.py *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68f2906c4db88329a4fef36bd0930d72