### PR TITLE
fix: Restore correct JSON schema in CRS and resampling prompts

### DIFF
--- a/src/prompts/crs.py
+++ b/src/prompts/crs.py
@@ -42,13 +42,20 @@ def register(mcp: FastMCP) -> None:
             "**Provide structured reasoning:**\n"
             "```json\n"
             "{\n"
-            f'  "crs": "{dst_crs}",\n'
             '  "intent": "property to preserve (e.g., area accuracy for land statistics)",\n'
-            '  "rationale": "why this CRS achieves the intent",\n'
-            '  "tradeoffs": "known distortions or limitations",\n'
-            '  "user_advisory": "if concerns exist, note them here (optional)"\n'
+            '  "alternatives": [\n'
+            '    {"method": "EPSG:XXXX", "why_not": "reason if considered"}\n'
+            "  ],\n"
+            '  "choice": {\n'
+            f'    "method": "{dst_crs}",\n'
+            '    "rationale": "why this CRS achieves the intent",\n'
+            '    "tradeoffs": "known distortions or limitations"\n'
+            "  },\n"
+            '  "confidence": "low|medium|high"\n'
             "}\n"
             "```\n\n"
+            "**Note:** The `alternatives` array is optional - include it if you genuinely "
+            "considered other options, otherwise use an empty array `[]`.\n\n"
             "If you have concerns about the user's choice, **ask them conversationally** "
             "before proceeding. Otherwise, document the reasoning and continue."
         )

--- a/src/prompts/resampling.py
+++ b/src/prompts/resampling.py
@@ -48,13 +48,21 @@ def register(mcp: FastMCP) -> None:
             "**Provide structured reasoning:**\n"
             "```json\n"
             "{\n"
-            f'  "method": "{method}",\n'
             '  "intent": "signal property to preserve (e.g., smooth gradients for elevation)",\n'
-            '  "rationale": "why this method achieves the intent",\n'
-            '  "tradeoffs": "artifacts or compromises",\n'
-            '  "user_advisory": "if concerns exist, note them here (optional)"\n'
+            '  "alternatives": [\n'
+            '    {"method": "nearest|bilinear|cubic|average|mode", '
+            '"why_not": "reason if considered"}\n'
+            "  ],\n"
+            '  "choice": {\n'
+            f'    "method": "{method}",\n'
+            '    "rationale": "why this method achieves the intent",\n'
+            '    "tradeoffs": "artifacts or compromises"\n'
+            "  },\n"
+            '  "confidence": "low|medium|high"\n'
             "}\n"
             "```\n\n"
+            "**Note:** The `alternatives` array is optional - include it if you genuinely "
+            "considered other options, otherwise use an empty array `[]`.\n\n"
             "If you have concerns about the user's choice, **ask them conversationally** "
             "before proceeding. Otherwise, document the reasoning and continue."
         )


### PR DESCRIPTION
CRITICAL FIX: The advisory prompt updates changed the JSON structure requested by prompts, but the validation schema (Justification in src/prompts/justification.py) was not updated to match.

Issue found by codex review:
- Prompts requested: crs/method, intent, rationale, tradeoffs, user_advisory
- Validator expects: intent, alternatives[], choice{}, confidence
- Result: All justifications would fail validation, blocking operations

Fix:
- Revert JSON schema in prompts to match Justification validator
- Keep advisory tone and guidance text (the actual UX improvement)
- Add note that alternatives[] is optional (can be empty array)
- Maintain backward compatibility with existing cache

Schema now correctly requests:
```json
{
  "intent": "...",
  "alternatives": [{"method": "...", "why_not": "..."}],
  "choice": {"method": "...", "rationale": "...", "tradeoffs": "..."},
  "confidence": "low|medium|high"
}
```

Impact:
- Advisory tone preserved (the real v1.0.1 improvement)
- Validation will now succeed
- No breaking changes to reflection pipeline
- Cache format unchanged

Note: Hydrology and aggregation prompts already had correct schema.

Verification:
✅ mypy src/prompts/ - Success
✅ ruff check src/prompts/ - All checks passed