### PR TITLE
Add configuration flags to reduce raster and vector tool surface

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -14,8 +14,8 @@ select = ["F", "E", "W", "I", "UP", "D", "B", "C4", "A", "ANN", "PLR"]
 ignore = [
   # Docstrings: prefer Numpy style, avoid prescriptive nitpicks.
   "D100", "D203", "D212", "D213", "D406", "D407", "D413",
-  # Annotations: soften for self/cls/__init__/Any at boundaries.
-  "ANN101", "ANN102", "ANN204", "ANN401",
+  # Annotations: soften for __init__/Any at boundaries.
+  "ANN204", "ANN401",
   # Pylint-ish complexity rules we don't want as blockers.
   "PLR0913", "PLR0912", "PLR0915",
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2025-10-27
+
+### Added
+
+- Environment variable toggles (`VECTOR`, `RASTER`) to enable or disable registration of vector/raster tool categories and their single-domain resources.
+- Dedicated environment variable reference linked from the README to document runtime configuration.
+
+### Changed
+
+- Server bootstrap now conditionally registers raster/vector tools and resources based on environment flags to reduce tool surface when needed.
+
 ## [1.1.1] - 2025-10-26
 
 ### 🎉 Major Feature Release - Vector Tool Parity & Cross-Domain Reflection

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ GDAL MCP is a Model Context Protocol (MCP) server that provides AI agents with g
 
 - **[Quick Start](QUICKSTART.md)** - Installation, setup, and MCP configuration
 - **[Tools Reference](TOOLS.md)** - Complete tool documentation with examples
+- **[Environment Variables](docs/ENVIRONMENT_VARIABLES.md)** - Runtime configuration and tool surface controls
 - **[Vision](docs/VISION.md)** - Long-term roadmap and philosophy
 - **[Changelog](CHANGELOG.md)** - Release history and updates
 

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -1,0 +1,20 @@
+# Environment Variables
+
+GDAL MCP supports a small set of environment variables to control workspace access and tool registration. Unless stated otherwise, unset variables fall back to their defaults.
+
+## Workspace Scoping
+- **`GDAL_MCP_WORKSPACES`** (string, optional)
+  - **Purpose:** Restrict tool access to a colon-separated allowlist of workspace directories.
+  - **Example:** `GDAL_MCP_WORKSPACES="/data/projects:/home/user/gis"`
+  - **Default:** Unset → all paths allowed (not recommended for production).
+
+## Tool Surface Controls
+Use these switches to reduce the available tool surface area. Values are case-insensitive and must be explicit.
+- **`VECTOR`** (boolean, default: `true`)
+  - **Purpose:** Enable (`1`/`true`) or disable (`0`/`false`) registration of all vector tools and vector-only resources.
+  - **Acceptable values:** `1`, `true`, `0`, `false`.
+- **`RASTER`** (boolean, default: `true`)
+  - **Purpose:** Enable (`1`/`true`) or disable (`0`/`false`) registration of all raster tools and raster-only resources.
+  - **Acceptable values:** `1`, `true`, `0`, `false`.
+
+When a category is disabled, its tools and single-domain resources are not registered with FastMCP. Shared prompts and cross-domain resources remain available.

--- a/src/config.py
+++ b/src/config.py
@@ -32,8 +32,7 @@ def _get_bool_env(var_name: str, *, default: bool = True) -> bool:
         return False
 
     logger.warning(
-        "Invalid value for %s: %s. Expected one of {1,true,0,false}. "
-        "Falling back to default=%s.",
+        "Invalid value for %s: %s. Expected one of {1,true,0,false}. Falling back to default=%s.",
         var_name,
         raw_value,
         default,

--- a/src/config.py
+++ b/src/config.py
@@ -21,7 +21,6 @@ def _get_bool_env(var_name: str, *, default: bool = True) -> bool:
     Any other value logs a warning and returns the default to avoid
     surprising behavior.
     """
-
     raw_value = os.getenv(var_name)
     if raw_value is None:
         return default
@@ -125,13 +124,11 @@ def reset_workspaces_cache() -> None:
 
 def is_vector_tools_enabled() -> bool:
     """Return whether vector tools and resources should register."""
-
     return _get_bool_env("VECTOR", default=True)
 
 
 def is_raster_tools_enabled() -> bool:
     """Return whether raster tools and resources should register."""
-
     return _get_bool_env("RASTER", default=True)
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -5,37 +5,53 @@ Ensures all tool modules are imported so their @mcp.tool functions register.
 
 from __future__ import annotations
 
+from src.config import is_raster_tools_enabled, is_vector_tools_enabled
+
+VECTOR_TOOLS_ENABLED = is_vector_tools_enabled()
+RASTER_TOOLS_ENABLED = is_raster_tools_enabled()
+
 # ===============================================================
-# resources/catalog
+# resources/catalog (always available)
 # ===============================================================
 import src.resources.catalog.all  # noqa: F401
 import src.resources.catalog.by_crs  # noqa: F401
-import src.resources.catalog.raster  # noqa: F401
 import src.resources.catalog.summary  # noqa: F401
-import src.resources.catalog.vector  # noqa: F401
+
+if RASTER_TOOLS_ENABLED:
+    import src.resources.catalog.raster  # noqa: F401
+
+if VECTOR_TOOLS_ENABLED:
+    import src.resources.catalog.vector  # noqa: F401
 
 # ===============================================================
 # resources/metadata
 # ===============================================================
-import src.resources.metadata.band  # noqa: F401
-import src.resources.metadata.raster  # noqa: F401
-import src.resources.metadata.statistics  # noqa: F401
-import src.resources.metadata.vector  # noqa: F401
-import src.tools.raster.convert  # noqa: F401
+if RASTER_TOOLS_ENABLED:
+    import src.resources.metadata.band  # noqa: F401
+    import src.resources.metadata.raster  # noqa: F401
+    import src.resources.metadata.statistics  # noqa: F401
+
+if VECTOR_TOOLS_ENABLED:
+    import src.resources.metadata.vector  # noqa: F401
 
 # ===============================================================
 # tools
 # ===============================================================
-import src.tools.raster.info  # noqa: F401
-import src.tools.raster.reproject  # noqa: F401
-import src.tools.raster.stats  # noqa: F401
+if RASTER_TOOLS_ENABLED:
+    import src.tools.raster.convert  # noqa: F401
+    import src.tools.raster.info  # noqa: F401
+    import src.tools.raster.reproject  # noqa: F401
+    import src.tools.raster.stats  # noqa: F401
+
+if VECTOR_TOOLS_ENABLED:
+    import src.tools.vector.buffer  # noqa: F401
+    import src.tools.vector.clip  # noqa: F401
+    import src.tools.vector.convert  # noqa: F401
+    import src.tools.vector.info  # noqa: F401
+    import src.tools.vector.reproject  # noqa: F401
+    import src.tools.vector.simplify  # noqa: F401
+
 import src.tools.reflection.store_justification  # noqa: F401
-import src.tools.vector.buffer  # noqa: F401
-import src.tools.vector.clip  # noqa: F401
-import src.tools.vector.convert  # noqa: F401
-import src.tools.vector.info  # noqa: F401
-import src.tools.vector.reproject  # noqa: F401
-import src.tools.vector.simplify  # noqa: F401
 
 # ===============================================================
 # prompts

--- a/src/server.py
+++ b/src/server.py
@@ -5,45 +5,45 @@ Ensures all tool modules are imported so their @mcp.tool functions register.
 
 from __future__ import annotations
 
-from src.config import is_raster_tools_enabled, is_vector_tools_enabled
-
-VECTOR_TOOLS_ENABLED = is_vector_tools_enabled()
-RASTER_TOOLS_ENABLED = is_raster_tools_enabled()
-
 # ===============================================================
 # resources/catalog (always available)
 # ===============================================================
 import src.resources.catalog.all  # noqa: F401
 import src.resources.catalog.by_crs  # noqa: F401
 import src.resources.catalog.summary  # noqa: F401
+from src.app import mcp
+from src.config import is_raster_tools_enabled, is_vector_tools_enabled
+from src.middleware.paths import PathValidationMiddleware
+from src.middleware.reflection_middleware import ReflectionMiddleware
+from src.prompts import register_prompts
 
-if RASTER_TOOLS_ENABLED:
+if is_raster_tools_enabled():
     import src.resources.catalog.raster  # noqa: F401
 
-if VECTOR_TOOLS_ENABLED:
+if is_vector_tools_enabled():
     import src.resources.catalog.vector  # noqa: F401
 
 # ===============================================================
 # resources/metadata
 # ===============================================================
-if RASTER_TOOLS_ENABLED:
+if is_raster_tools_enabled():
     import src.resources.metadata.band  # noqa: F401
     import src.resources.metadata.raster  # noqa: F401
     import src.resources.metadata.statistics  # noqa: F401
 
-if VECTOR_TOOLS_ENABLED:
+if is_vector_tools_enabled():
     import src.resources.metadata.vector  # noqa: F401
 
 # ===============================================================
 # tools
 # ===============================================================
-if RASTER_TOOLS_ENABLED:
+if is_raster_tools_enabled():
     import src.tools.raster.convert  # noqa: F401
     import src.tools.raster.info  # noqa: F401
     import src.tools.raster.reproject  # noqa: F401
     import src.tools.raster.stats  # noqa: F401
 
-if VECTOR_TOOLS_ENABLED:
+if is_vector_tools_enabled():
     import src.tools.vector.buffer  # noqa: F401
     import src.tools.vector.clip  # noqa: F401
     import src.tools.vector.convert  # noqa: F401
@@ -56,11 +56,6 @@ import src.tools.reflection.store_justification  # noqa: F401
 # ===============================================================
 # prompts
 # ===============================================================
-from src.app import mcp
-from src.middleware.paths import PathValidationMiddleware
-from src.middleware.reflection_middleware import ReflectionMiddleware
-from src.prompts import register_prompts
-
 # Register prompts (the epistemic layer)
 register_prompts(mcp)
 


### PR DESCRIPTION
## Summary
- add VECTOR and RASTER environment toggles and document all runtime environment variables
- gate raster and vector tool/resource registration on the new flags to reduce tool surface when disabled
- link the environment variable reference from the README and note the change in the changelog

## Testing
- uv run pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920f88e9c48832980f3747bd9ff6d35)